### PR TITLE
Allow to build components for a specific module on demand.

### DIFF
--- a/component/builder.py
+++ b/component/builder.py
@@ -10,11 +10,9 @@ Components Builder
 Build the components at the build of a registry.
 
 """
-
 import odoo
 from odoo import api, models
 from .core import (
-    MetaComponent,
     _component_databases,
     ComponentRegistry,
     DEFAULT_CACHE_SIZE,
@@ -66,6 +64,7 @@ class ComponentBuilder(models.AbstractModel):
             "SELECT name "
             "FROM ir_module_module "
             "WHERE state IN ('installed', 'to upgrade', 'to update')"
+
         )
         module_list = [name for (name,) in self.env.cr.fetchall()
                        if name not in graph]
@@ -76,7 +75,7 @@ class ComponentBuilder(models.AbstractModel):
 
         components_registry.ready = True
 
-    def load_components(self, module, components_registry):
+    def load_components(self, module, components_registry=None):
         """ Build every component known by MetaComponent for an odoo module
 
         The final component (composed by all the Component classes in this
@@ -88,5 +87,7 @@ class ComponentBuilder(models.AbstractModel):
         :param registry: the registry in which we want to put the Component
         :type registry: :py:class:`~.core.ComponentRegistry`
         """
-        for component_class in MetaComponent._modules_components[module]:
-            component_class._build_component(components_registry)
+        components_registry = (
+            components_registry or
+            _component_databases[self.env.cr.dbname])
+        components_registry.load_components(module)

--- a/component/core.py
+++ b/component/core.py
@@ -78,6 +78,7 @@ class ComponentRegistry(object):
     def __init__(self, cachesize=DEFAULT_CACHE_SIZE):
         self._cache = LRUCache(maxsize=cachesize)
         self._components = OrderedDict()
+        self._loaded_modules = set()
         self.ready = False
 
     def __getitem__(self, key):
@@ -94,6 +95,13 @@ class ComponentRegistry(object):
 
     def __iter__(self):
         return iter(self._components)
+
+    def load_components(self, module):
+        if module in self._loaded_modules:
+            return
+        for component_class in MetaComponent._modules_components[module]:
+            component_class._build_component(self)
+        self._loaded_modules.add(module)
 
     @cachedmethod(operator.attrgetter('_cache'))
     def lookup(self, collection_name=None, usage=None, model_name=None):


### PR DESCRIPTION
When a module is loaded with test-enable=True, the components of this module are not registerd by the call to the method _register_hook of the component.builder. Indeed the state of the module is still *to install*. This change allows to call the method *load_components* on the component.builder for a specific module by taking care to not reload the components of a module already loaded.

This change is required to be able to load the component registry into the tests. For example if we want to test the module 'my_connector' defining a lot of component we must write into the `setUp` method of our test case:
```python
    def setUp(self):
        super(MyTestCase, self).setUp()
        self.component_builder = self.env['component.builder']
        self.component_builder._register_hook()
        self.component_builder.load_components('my_connector')
```